### PR TITLE
Update travel logic immediately after a path is generated

### DIFF
--- a/lua/copbrain.lua
+++ b/lua/copbrain.lua
@@ -6,6 +6,14 @@ Hooks:PostHook(CopBrain, "post_init", "sh_post_init", function (self)
 	end
 end)
 
+-- Update immediately once we have our pathing results instead of waiting for the next update
+Hooks:PostHook(CopBrain, "clbk_pathing_results", "sh_clbk_pathing_results", function (self)
+	local current_logic = self._current_logic
+	if current_logic.clbk_pathing_results then
+		current_logic.clbk_pathing_results(self._logic_data)
+	end
+end)
+
 local set_important_original = CopBrain.set_important
 function CopBrain:set_important(state, ...)
 	return set_important_original(self, self._forced_important and true or state, ...)

--- a/lua/coplogictravel.lua
+++ b/lua/coplogictravel.lua
@@ -124,3 +124,14 @@ function CopLogicTravel._chk_start_pathing_to_next_nav_point(data, my_data)
 
 	data.unit:brain():search_for_path(my_data.advance_path_search_id, to_pos, prio, nil, nav_segs)
 end
+
+function CopLogicTravel.clbk_pathing_results(data)
+	local my_data = data.internal_data
+	data.t = TimerManager:game():time()
+
+	CopLogicTravel._upd_enemy_detection(data)
+
+	if data.internal_data == my_data then
+		CopLogicTravel.upd_advance(data)
+	end
+end


### PR DESCRIPTION
This can also be extended to the other logics as well, travel logic just obviously benefits the most